### PR TITLE
[UP-676] changed default video type

### DIFF
--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -208,7 +208,7 @@ bool WebVideoServer::handle_stream(const async_web_server_cpp::HttpRequest &requ
       if (!did_find_compressed_topic)
       {
         RCLCPP_WARN(nh_->get_logger(), "Could not find compressed image topic for %s, falling back to mjpeg", topic.c_str());
-        type = "mjpeg";
+        type = "vp8";
       }
     }
     boost::shared_ptr<ImageStreamer> streamer = stream_types_[type]->create_streamer(request, connection, nh_);


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (UP-676) |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation of Tally) |

---

## Description of contribution in a few bullet points

<!--
* I changed the config summary and deleted useless info and buttons
* Disabled reset button during mission launched
* Created a warning for stop mission
* Cleaned some logging
* Included a pre-drawing of the mission path on the map
* corrected a couple of syntax errors.
*  Also check (Bugs final delivery January 28th) https://unmannedlife.atlassian.net/wiki/spaces/UL/pages/2106228737/Telefonica+Outdoor+demokit+29+11+21-+03+12+21
-->

changed the default video format from jpeg to vp8

## Description of documentation updates required from your changes

<!--
* NA
-->

---

## Future work that may be required in bullet points

<!--
* The approach to the timer for the gps status, IS NOT THE BEST, and should be refactored with info from the backend. 
* Possibly using navsatFix.status
-->
